### PR TITLE
fix justify layout jumping by removing kerning

### DIFF
--- a/src/app/hooks/use-typewriter.tsx
+++ b/src/app/hooks/use-typewriter.tsx
@@ -45,10 +45,15 @@ const useTypewriter = ({
   const typewritten = text.slice(0, length);
   const untyped = text.slice(length);
   const element: JSX.Element = (
-    <>
+    <span
+      style={{
+        letterSpacing: "0.01em",
+        fontKerning: "none",
+      }}
+    >
       {linkProps ? <Link {...linkProps}>{typewritten}</Link> : typewritten}
       <span style={{ color: "transparent" }}>{untyped}</span>
-    </>
+    </span>
   );
 
   return {


### PR DESCRIPTION
I think this still might not be perfect but this has been really difficult to test. I only spotted the original visual bug because my own phone happened to be the exact right size to cause the problem. As of now this looks good on web (where it was never a problem, at least in chrome, because it could persist kerning across span boundaries) and now looks good on iphone SE and iphone 16 pro.