### PR TITLE
feat: add dark mode compatibility

### DIFF
--- a/src/app/components/footer.tsx
+++ b/src/app/components/footer.tsx
@@ -1,5 +1,4 @@
-import { Box, Link, Typography } from "@mui/material";
-import styled from "styled-components";
+import { Box, Link, Typography, styled } from "@mui/material";
 
 const FooterContainer = styled(Box)({
   width: "100%",

--- a/src/app/components/footer.tsx
+++ b/src/app/components/footer.tsx
@@ -6,9 +6,10 @@ const FooterContainer = styled(Box)({
   justifyContent: "center",
 });
 
-const CenteredTypography = styled(Typography)({
+const CenteredTypography = styled(Typography)(({ theme }) => ({
+  color: theme.palette.secondary.main,
   textAlign: "center",
-});
+}));
 
 const Footer = () => {
   return (

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -1,7 +1,11 @@
-import { Box, Button, styled } from "@mui/material";
+import { Box, Button, FormControlLabel, styled } from "@mui/material";
 import { usePathname, useRouter } from "next/navigation";
 import { sizes } from "@constants";
 import { ReactNode } from "react";
+import { Switch } from "@mui/material";
+import { useColorScheme } from "@mui/material/styles";
+import Brightness3Icon from "@mui/icons-material/Brightness3";
+import Brightness7Icon from "@mui/icons-material/Brightness7";
 
 const HeaderContainer = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.primary.main,
@@ -12,6 +16,7 @@ const HeaderContainer = styled(Box)(({ theme }) => ({
   width: "100%",
   overflowX: "auto",
   zIndex: 1000,
+  display: "flex",
 }));
 
 const HeaderContent = styled(Box)({
@@ -32,6 +37,16 @@ const SelectedNavButton = styled(NavButton)(({ theme }) => ({
   color: theme.palette.primary.light,
   backgroundColor: theme.palette.primary.dark,
 }));
+
+const StyledFormControlLabel = styled(FormControlLabel)(({ theme }) => ({
+  color: theme.palette.primary.contrastText,
+  marginLeft: "auto",
+}));
+
+const LabelIconContainer = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+});
 
 const NavLink = ({
   children,
@@ -57,6 +72,15 @@ export type HeaderProps = {
 const Header = ({ routes }: HeaderProps) => {
   const router = useRouter();
   const pathname = usePathname();
+  const { mode, setMode } = useColorScheme();
+  if (!mode) {
+    return null;
+  }
+
+  const isDarkMode = mode === "dark";
+  const toggleDarkMode = () => {
+    setMode(isDarkMode ? "light" : "dark");
+  };
   return (
     <HeaderContainer>
       <HeaderContent>
@@ -71,6 +95,21 @@ const Header = ({ routes }: HeaderProps) => {
           </NavLink>
         ))}
       </HeaderContent>
+      <StyledFormControlLabel
+        control={
+          <Switch
+            checked={isDarkMode}
+            onChange={toggleDarkMode}
+            color="default"
+          />
+        }
+        label={
+          <LabelIconContainer>
+            {isDarkMode ? <Brightness7Icon /> : <Brightness3Icon />}
+          </LabelIconContainer>
+        }
+        aria-label="Dark Mode Switch"
+      />
     </HeaderContainer>
   );
 };

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -103,13 +103,11 @@ const Header = ({ routes }: HeaderProps) => {
   const navLinksRef = useRef<HTMLDivElement>(null);
   const [isOverflowingLeft, setIsOverflowingLeft] = useState(false);
   const [isOverflowingRight, setIsOverflowingRight] = useState(false);
-  console.log("overflowing", { isOverflowingLeft, isOverflowingRight });
 
   useEffect(() => {
     const checkOverflow = () => {
       if (navLinksRef.current) {
         const { scrollLeft, scrollWidth, clientWidth } = navLinksRef.current;
-        console.log("navLinksRef", { scrollLeft, scrollWidth, clientWidth });
         setIsOverflowingLeft(scrollLeft > 0);
         setIsOverflowingRight(scrollLeft + clientWidth < scrollWidth);
       }

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, FormControlLabel, styled } from "@mui/material";
 import { usePathname, useRouter } from "next/navigation";
 import { sizes } from "@constants";
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode, useCallback, useState } from "react";
 import { Switch } from "@mui/material";
 import { useColorScheme } from "@mui/material/styles";
 import Brightness7Icon from "@mui/icons-material/Brightness7";
@@ -100,29 +100,25 @@ const Header = ({ routes }: HeaderProps) => {
   const router = useRouter();
   const pathname = usePathname();
   const { mode, setMode } = useColorScheme();
-  const navLinksRef = useRef<HTMLDivElement>(null);
   const [isOverflowingLeft, setIsOverflowingLeft] = useState(false);
   const [isOverflowingRight, setIsOverflowingRight] = useState(false);
 
-  useEffect(() => {
-    const checkOverflow = () => {
-      if (navLinksRef.current) {
-        const { scrollLeft, scrollWidth, clientWidth } = navLinksRef.current;
+  const navLinksRef = useCallback((node: HTMLDivElement) => {
+    if (node !== null) {
+      const checkOverflow = () => {
+        const { scrollLeft, scrollWidth, clientWidth } = node;
         setIsOverflowingLeft(scrollLeft > 0);
         setIsOverflowingRight(scrollLeft + clientWidth < scrollWidth);
-      }
-    };
+      };
+      checkOverflow(); // Check on mount
+      node.addEventListener("scroll", checkOverflow);
+      window.addEventListener("resize", checkOverflow);
 
-    checkOverflow(); // Check on mount
-    window.addEventListener("resize", checkOverflow); // Check on resize
-    navLinksRef.current?.addEventListener("scroll", checkOverflow); // Check on scroll
-
-    const navLinksRefCurrentCopy = navLinksRef.current;
-
-    return () => {
-      window.removeEventListener("resize", checkOverflow);
-      navLinksRefCurrentCopy?.removeEventListener("scroll", checkOverflow);
-    };
+      return () => {
+        node.removeEventListener("scroll", checkOverflow);
+        window.removeEventListener("resize", checkOverflow);
+      };
+    }
   }, []);
 
   if (!mode) {

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -35,32 +35,20 @@ const NavLinks = styled(Box)(({ theme }) => ({
 const OverflowFade = styled(Box)(({ theme }) => ({
   position: "absolute",
   top: 0,
-  left: 0,
   bottom: 0,
-  width: 32,
-  pointerEvents: "none", // Ensure it doesn't interfere with scrolling
+  width: 48,
+  pointerEvents: "none",
+  zIndex: 1,
 }));
 
-const OverflowRightFade = styled(Box)(({ theme }) => ({
-  position: "absolute",
-  top: 0,
+const OverflowRightFade = styled(OverflowFade)(({ theme }) => ({
   right: 0,
-  bottom: 0,
-  width: 32,
-  pointerEvents: "none", // Ensure it doesn't interfere with scrolling
   background: `linear-gradient(to left, ${theme.palette.primary.main}, transparent)`,
-  zIndex: 1,
 }));
 
-const OverflowLeftFade = styled(Box)(({ theme }) => ({
-  position: "absolute",
-  top: 0,
+const OverflowLeftFade = styled(OverflowFade)(({ theme }) => ({
   left: 0,
-  bottom: 0,
-  width: 32,
-  pointerEvents: "none", // Ensure it doesn't interfere with scrolling
   background: `linear-gradient(to right, ${theme.palette.primary.main}, transparent)`,
-  zIndex: 1,
 }));
 
 const NavButton = styled(Button)(({ theme }) => ({

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -25,21 +25,21 @@ const NavLinksContainer = styled(Box)({
   overflow: "hidden",
 });
 
-const NavLinks = styled(Box)(({ theme }) => ({
+const NavLinks = styled(Box)({
   display: "flex",
   overflowX: "auto",
   gap: 8,
   position: "relative",
-}));
+});
 
-const OverflowFade = styled(Box)(({ theme }) => ({
+const OverflowFade = styled(Box)({
   position: "absolute",
   top: 0,
   bottom: 0,
   width: 48,
   pointerEvents: "none",
   zIndex: 1,
-}));
+});
 
 const OverflowRightFade = styled(OverflowFade)(({ theme }) => ({
   right: 0,
@@ -117,11 +117,13 @@ const Header = ({ routes }: HeaderProps) => {
     window.addEventListener("resize", checkOverflow); // Check on resize
     navLinksRef.current?.addEventListener("scroll", checkOverflow); // Check on scroll
 
+    const navLinksRefCurrentCopy = navLinksRef.current;
+
     return () => {
       window.removeEventListener("resize", checkOverflow);
-      navLinksRef.current?.removeEventListener("scroll", checkOverflow);
+      navLinksRefCurrentCopy?.removeEventListener("scroll", checkOverflow);
     };
-  }, [navLinksRef.current]);
+  }, []);
 
   if (!mode) {
     return null;

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -1,11 +1,11 @@
 import { Box, Button, FormControlLabel, styled } from "@mui/material";
 import { usePathname, useRouter } from "next/navigation";
 import { sizes } from "@constants";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { Switch } from "@mui/material";
 import { useColorScheme } from "@mui/material/styles";
-import Brightness3Icon from "@mui/icons-material/Brightness3";
 import Brightness7Icon from "@mui/icons-material/Brightness7";
+import NightlightIcon from "@mui/icons-material/Nightlight";
 
 const HeaderContainer = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.primary.main,
@@ -14,19 +14,58 @@ const HeaderContainer = styled(Box)(({ theme }) => ({
   top: 0,
   left: 0,
   width: "100%",
-  overflowX: "auto",
   zIndex: 1000,
   display: "flex",
 }));
 
-const HeaderContent = styled(Box)({
+const NavLinksContainer = styled(Box)({
   display: "flex",
-  minWidth: "fit-content",
-  gap: 8,
+  flexGrow: 1,
+  position: "relative",
+  overflow: "hidden",
 });
+
+const NavLinks = styled(Box)(({ theme }) => ({
+  display: "flex",
+  overflowX: "auto",
+  gap: 8,
+  position: "relative",
+}));
+
+const OverflowFade = styled(Box)(({ theme }) => ({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  bottom: 0,
+  width: 32,
+  pointerEvents: "none", // Ensure it doesn't interfere with scrolling
+}));
+
+const OverflowRightFade = styled(Box)(({ theme }) => ({
+  position: "absolute",
+  top: 0,
+  right: 0,
+  bottom: 0,
+  width: 32,
+  pointerEvents: "none", // Ensure it doesn't interfere with scrolling
+  background: `linear-gradient(to left, ${theme.palette.primary.main}, transparent)`,
+  zIndex: 1,
+}));
+
+const OverflowLeftFade = styled(Box)(({ theme }) => ({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  bottom: 0,
+  width: 32,
+  pointerEvents: "none", // Ensure it doesn't interfere with scrolling
+  background: `linear-gradient(to right, ${theme.palette.primary.main}, transparent)`,
+  zIndex: 1,
+}));
 
 const NavButton = styled(Button)(({ theme }) => ({
   gap: 8,
+  flexShrink: 0,
   color: theme.palette.primary.contrastText,
   backgroundColor: "transparent",
   "&:hover": {
@@ -73,6 +112,31 @@ const Header = ({ routes }: HeaderProps) => {
   const router = useRouter();
   const pathname = usePathname();
   const { mode, setMode } = useColorScheme();
+  const navLinksRef = useRef<HTMLDivElement>(null);
+  const [isOverflowingLeft, setIsOverflowingLeft] = useState(false);
+  const [isOverflowingRight, setIsOverflowingRight] = useState(false);
+  console.log("overflowing", { isOverflowingLeft, isOverflowingRight });
+
+  useEffect(() => {
+    const checkOverflow = () => {
+      if (navLinksRef.current) {
+        const { scrollLeft, scrollWidth, clientWidth } = navLinksRef.current;
+        console.log("navLinksRef", { scrollLeft, scrollWidth, clientWidth });
+        setIsOverflowingLeft(scrollLeft > 0);
+        setIsOverflowingRight(scrollLeft + clientWidth < scrollWidth);
+      }
+    };
+
+    checkOverflow(); // Check on mount
+    window.addEventListener("resize", checkOverflow); // Check on resize
+    navLinksRef.current?.addEventListener("scroll", checkOverflow); // Check on scroll
+
+    return () => {
+      window.removeEventListener("resize", checkOverflow);
+      navLinksRef.current?.removeEventListener("scroll", checkOverflow);
+    };
+  }, [navLinksRef.current]);
+
   if (!mode) {
     return null;
   }
@@ -83,18 +147,22 @@ const Header = ({ routes }: HeaderProps) => {
   };
   return (
     <HeaderContainer>
-      <HeaderContent>
-        {routes.map(({ route, Icon, label }) => (
-          <NavLink
-            isCurrentTab={pathname === route}
-            key={route}
-            onClick={() => router.push(route)}
-          >
-            <Icon />
-            {label}
-          </NavLink>
-        ))}
-      </HeaderContent>
+      <NavLinksContainer>
+        {isOverflowingLeft && <OverflowLeftFade />}
+        <NavLinks ref={navLinksRef}>
+          {routes.map(({ route, Icon, label }) => (
+            <NavLink
+              isCurrentTab={pathname === route}
+              key={route}
+              onClick={() => router.push(route)}
+            >
+              <Icon />
+              {label}
+            </NavLink>
+          ))}
+        </NavLinks>
+        {isOverflowingRight && <OverflowRightFade />}
+      </NavLinksContainer>
       <StyledFormControlLabel
         control={
           <Switch
@@ -105,7 +173,7 @@ const Header = ({ routes }: HeaderProps) => {
         }
         label={
           <LabelIconContainer>
-            {isDarkMode ? <Brightness7Icon /> : <Brightness3Icon />}
+            {isDarkMode ? <Brightness7Icon /> : <NightlightIcon />}
           </LabelIconContainer>
         }
         aria-label="Dark Mode Switch"

--- a/src/app/components/theme-toggle.tsx
+++ b/src/app/components/theme-toggle.tsx
@@ -1,9 +1,5 @@
-import { Switch, styled } from "@mui/material";
+import { Switch } from "@mui/material";
 import { useColorScheme } from "@mui/material/styles";
-
-const StyledSwitch = styled(Switch)(({ theme }) => ({
-  color: theme.palette.secondary.main,
-}));
 
 const ThemeToggle = () => {
   const { mode, setMode } = useColorScheme();

--- a/src/app/components/theme-toggle.tsx
+++ b/src/app/components/theme-toggle.tsx
@@ -1,0 +1,23 @@
+import { Switch, styled } from "@mui/material";
+import { useColorScheme } from "@mui/material/styles";
+
+const StyledSwitch = styled(Switch)(({ theme }) => ({
+  color: theme.palette.secondary.main,
+}));
+
+const ThemeToggle = () => {
+  const { mode, setMode } = useColorScheme();
+  if (!mode) {
+    return null;
+  }
+
+  const isDarkMode = mode === "dark";
+  const toggleDarkMode = () => {
+    setMode(isDarkMode ? "light" : "dark");
+  };
+  return (
+    <Switch checked={isDarkMode} onChange={toggleDarkMode} color="default" />
+  );
+};
+
+export default ThemeToggle;

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,5 @@
 "use client";
-import { Box, Link, Typography } from "@mui/material";
-import styled from "styled-components";
+import { Box, Link, Typography, styled } from "@mui/material";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import LinkedInIcon from "@mui/icons-material/LinkedIn";
 import MailOutlineIcon from "@mui/icons-material/MailOutline";
@@ -26,14 +25,18 @@ const ContactLinkContent = styled(Box)({
   gap: 8,
 });
 
+const ColoredTypography = styled(Typography)(({ theme }) => ({
+  color: theme.palette.secondary.main,
+}));
+
 const Contact = () => {
   return (
     <PageContainer>
       <ContentContainer>
-        <Typography variant="body1">
+        <ColoredTypography variant="body1">
           The best way to reach me is by email but I should also receive a
           notification and respond if you message me on LinkedIn
-        </Typography>
+        </ColoredTypography>
         <Link href="mailto:jon.kiersey@gmail.com">
           <ContactLinkContent>
             <MailOutlineIcon />

--- a/src/app/home/approval-counter.tsx
+++ b/src/app/home/approval-counter.tsx
@@ -14,6 +14,7 @@ const ApprovalButton = styled(Button)({
   width: 200,
   alignSelf: "center",
   display: "inline-flex",
+  marginTop: 16,
 });
 
 const ApprovalBox = styled(Box)(({ theme }) => ({
@@ -23,6 +24,7 @@ const ApprovalBox = styled(Box)(({ theme }) => ({
   border: "1px solid",
   borderColor: theme.palette.primary.main,
   borderRadius: 8,
+  color: theme.palette.secondary.main,
   padding: 16,
   marginTop: 64,
   [theme.breakpoints.down("sm")]: {

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -32,7 +32,7 @@ const CenteredTypography = styled(Typography)(({ theme }) => ({
 }));
 
 const NameTypography = styled(CenteredTypography)(({ theme }) => ({
-  color: theme.palette.primary.dark,
+  color: theme.palette.primary.main,
 }));
 
 const FadeInContainer = styled(Box)({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,7 +71,7 @@ const RootLayout = ({
 
   useEffect(() => {
     setMode(prefersDarkMode ? "dark" : "light");
-  }, [prefersDarkMode]);
+  }, [prefersDarkMode, setMode]);
   const approvals = useApprovals();
   return (
     <html lang="en">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,13 @@
 "use client";
-import { Box, ThemeProvider } from "@mui/material";
+import {
+  Box,
+  ThemeProvider,
+  styled,
+  useColorScheme,
+  useMediaQuery,
+} from "@mui/material";
 import theme from "../theme";
 import { Footer, Header } from "./components";
-import styled from "styled-components";
 import { sizes } from "@constants";
 import { HeaderProps } from "./components/header";
 import ConstructionIcon from "@mui/icons-material/Construction";
@@ -13,6 +18,7 @@ import WorkIcon from "@mui/icons-material/Work";
 import Head from "next/head";
 import useApprovals from "./hooks/use-approvals";
 import ApprovalsContext from "./contexts/approvals-context";
+import { useEffect } from "react";
 
 const ContentContainer = styled(Box)({
   flexGrow: 1,
@@ -20,11 +26,12 @@ const ContentContainer = styled(Box)({
   boxSizing: "border-box",
 });
 
-const PageContainer = styled(Box)({
+const PageContainer = styled(Box)(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   minHeight: "100vh",
-});
+  background: theme.palette.background.default,
+}));
 
 const navHeaderRoutes: HeaderProps["routes"] = [
   {
@@ -59,6 +66,12 @@ const RootLayout = ({
 }: Readonly<{
   children: React.ReactNode;
 }>) => {
+  const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
+  const { mode, setMode } = useColorScheme();
+
+  useEffect(() => {
+    setMode(prefersDarkMode ? "dark" : "light");
+  }, [prefersDarkMode]);
   const approvals = useApprovals();
   return (
     <html lang="en">
@@ -67,7 +80,7 @@ const RootLayout = ({
       </Head>
       <body style={{ margin: 0, height: "100vh" }}>
         <main>
-          <ThemeProvider theme={theme}>
+          <ThemeProvider theme={theme} defaultMode={mode}>
             <ApprovalsContext.Provider value={approvals}>
               <PageContainer>
                 <Header routes={navHeaderRoutes} />

--- a/src/app/projects/components/project-card.tsx
+++ b/src/app/projects/components/project-card.tsx
@@ -2,7 +2,6 @@ import { Box, Card, Link, styled, Typography } from "@mui/material";
 import Image, { StaticImageData } from "next/image";
 
 const ContainerCard = styled(Card)(({ theme }) => ({
-  backgroundColor: theme.palette.grey[100],
   display: "flex",
   flexDirection: "column",
   padding: 16,

--- a/src/app/resume/components/main-content.tsx
+++ b/src/app/resume/components/main-content.tsx
@@ -9,11 +9,12 @@ import {
 } from "@mui/material";
 import { WorkExperience } from "../types";
 
-const MainContentContainer = styled(Box)({
+const MainContentContainer = styled(Box)(({ theme }) => ({
+  color: theme.palette.secondary.main,
   display: "flex",
   flexDirection: "column",
   padding: 16,
-});
+}));
 
 const HeaderBox = styled(Box)({
   display: "flex",

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,13 +1,43 @@
 import { createTheme } from "@mui/material/styles";
-import { grey } from "@mui/material/colors";
+import { grey, blue } from "@mui/material/colors";
 
-export default createTheme({
-  palette: {
-    secondary: {
-      light: grey[400],
-      main: grey[600],
-      dark: grey[800],
-      contrastText: grey[100],
+const theme = createTheme({
+  colorSchemes: {
+    light: {
+      palette: {
+        primary: {
+          main: blue[500],
+        },
+        secondary: {
+          light: grey[400],
+          main: grey[600],
+          dark: grey[800],
+          contrastText: grey[100],
+        },
+        background: {
+          default: "#ffffff",
+          paper: "#f5f5f5",
+        },
+      },
+    },
+    dark: {
+      palette: {
+        primary: {
+          main: blue[200],
+        },
+        secondary: {
+          light: grey[200],
+          main: grey[400],
+          dark: grey[600],
+          contrastText: grey[800],
+        },
+        background: {
+          default: "#121212",
+          paper: "#1d1d1d",
+        },
+      },
     },
   },
 });
+
+export default theme;


### PR DESCRIPTION
Adds dark mode compatibility.
Adds dark/light mode toggle on header.
Fades overflowing nav links to show that there are more to scroll to.

Unrelated: fixes wrong imports of `styled` from `styled-components` to `@mui/material`